### PR TITLE
Add HasPermission decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ class MyController {
 }
 ```
 
+In order check that the user has a valid accessToken, but without any required permission or roles you can use the `@Authenticated` decorator without any tokenType.
+
+```typescript
+import { HasPermission } from "@moveaxlab/nestjs-security";
+import { Authenticated } from "./authenticated.decorator";
+
+@Authenticated()
+class MyController {
+  async getMyProfile() {
+    // only accessibile to authenticated user
+  }
+}
+```
+
 ### @HasPermission
 
 The library will search for the required permission in the `permissions` array.
@@ -108,25 +122,12 @@ import { HasPermission } from "@moveaxlab/nestjs-security";
 @HasPermission("myResource.read")
 class MyController {
   async firstMethod() {
-    // accessible to both admins and users
+    // accessible to token with permission myResource.read
   }
 
   @HasPermission("myResource.write")
   async secondMethod() {
-    // only accessible to admins
-  }
-}
-```
-
-The library also accept the wildcard `*` has permission, to check that the user has a valid accessToken, but without any required permission.
-
-```typescript
-import { HasPermission } from "@moveaxlab/nestjs-security";
-
-@HasPermission("*")
-class MyController {
-  async getMyProfile() {
-    // use the token here
+    // only accessible to token with the permissions myResourse.write
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The library assumes that all access tokens contain a `tokenType` field or a `per
 Authentication can be applied on the class level or on the method level.
 
 ### @Authenticated
+
 The library will check that the token type is equal with one of the roles declared in the decorator
 
 ```typescript
@@ -96,7 +97,9 @@ class MyController {
   }
 }
 ```
+
 ### @HasPermission
+
 The library will search for the required permission in the `permissions` array.
 
 ```typescript
@@ -118,9 +121,7 @@ class MyController {
 The library also accept the wildcard `*` has permission, to check that the user has a valid accessToken, but without any required permission.
 
 ```typescript
-import {
-  HasPermission,
-} from "@moveaxlab/nestjs-security";
+import { HasPermission } from "@moveaxlab/nestjs-security";
 
 @HasPermission("*")
 class MyController {
@@ -227,10 +228,10 @@ You can access the parsed access token and refresh token
 inside your controllers and resolvers using decorators.
 
 ```typescript
-import { 
-  Authenticated, 
+import {
+  Authenticated,
   AccessToken,
-  HasPermission
+  HasPermission,
 } from "@moveaxlab/nestjs-security";
 
 interface User {
@@ -247,7 +248,7 @@ class MyController {
   }
 }
 
-@HasPermission('myPermission')
+@HasPermission("myPermission")
 class MySecondController {
   async mySecondMethod(@AccessToken() token: User) {
     // use the token here

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ custom transformations on the parsed access token.
 
 ## Authenticating users
 
-You can authenticate users based on their role (or token type).
-The library assumes that all access tokens contain a `tokenType` field.
+You can authenticate users based on their role (or token type) or based on the permission.
+The library assumes that all access tokens contain a `tokenType` field or a `permissions` array.
 Authentication can be applied on the class level or on the method level.
+
+### @Authenticated
+The library will check that the token type is equal with one of the roles declared in the decorator
 
 ```typescript
 import { Authenticated } from "@moveaxlab/nestjs-security";
@@ -90,6 +93,39 @@ class MyController {
   @Authenticated("admin")
   async secondMethod() {
     // only accessible to admins
+  }
+}
+```
+### @HasPermission
+The library will search for the required permission in the `permissions` array.
+
+```typescript
+import { HasPermission } from "@moveaxlab/nestjs-security";
+
+@HasPermission("myResource.read")
+class MyController {
+  async firstMethod() {
+    // accessible to both admins and users
+  }
+
+  @HasPermission("myResource.write")
+  async secondMethod() {
+    // only accessible to admins
+  }
+}
+```
+
+The library also accept the wildcard `*` has permission, to check that the user has a valid accessToken, but without any required permission.
+
+```typescript
+import {
+  HasPermission,
+} from "@moveaxlab/nestjs-security";
+
+@HasPermission("*")
+class MyController {
+  async getMyProfile() {
+    // use the token here
   }
 }
 ```
@@ -191,17 +227,29 @@ You can access the parsed access token and refresh token
 inside your controllers and resolvers using decorators.
 
 ```typescript
-import { Authenticated, AccessToken } from "@moveaxlab/nestjs-security";
+import { 
+  Authenticated, 
+  AccessToken,
+  HasPermission
+} from "@moveaxlab/nestjs-security";
 
 interface User {
   tokenType: "admin" | "user";
   uid: string;
+  permission: string[];
   // other information contained in the token
 }
 
 @Authenticated("admin")
 class MyController {
   async myMethod(@AccessToken() token: User) {
+    // use the token here
+  }
+}
+
+@HasPermission('myPermission')
+class MySecondController {
+  async mySecondMethod(@AccessToken() token: User) {
     // use the token here
   }
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,3 +3,4 @@ export const SECURITY_CONFIG_INJECTION_KEY = "@moveax/security-config";
 export const REDIS_INJECTION_KEY = "@moveax/security-redis";
 
 export const TOKEN_TYPES_METADATA_KEY = "@moveax/token-type-metadata-key";
+export const PERMISSIONS_METADATA_KEY = "@moveax/permission-metadata-key";

--- a/src/decorators/authenticated/authenticated.decorator.ts
+++ b/src/decorators/authenticated/authenticated.decorator.ts
@@ -1,6 +1,6 @@
 import { applyDecorators, UseGuards } from "@nestjs/common";
 import { TokenTypes } from "./token-types.decorator";
-import { AuthGuard } from "./auth.guard";
+import { AuthGuard } from "../auth.guard";
 import { TokenTypeGuard } from "./token-type.guard";
 
 /**

--- a/src/decorators/authenticated/token-type.guard.ts
+++ b/src/decorators/authenticated/token-type.guard.ts
@@ -6,8 +6,8 @@ import {
   Dependencies,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
-import { getRequest } from "../utils";
-import { TOKEN_TYPES_METADATA_KEY } from "../constants";
+import { getRequest } from "../../utils";
+import { TOKEN_TYPES_METADATA_KEY } from "../../constants";
 
 @Dependencies(Reflector)
 @Injectable()

--- a/src/decorators/authenticated/token-type.guard.ts
+++ b/src/decorators/authenticated/token-type.guard.ts
@@ -26,12 +26,14 @@ export class TokenTypeGuard implements CanActivate {
     const allowedTokenTypes = (this.reflector.get(
       TOKEN_TYPES_METADATA_KEY,
       context.getHandler(),
-    ) ||
-      this.reflector.get(
-        TOKEN_TYPES_METADATA_KEY,
-        context.getClass(),
-      )) as string[];
+    ) || this.reflector.get(TOKEN_TYPES_METADATA_KEY, context.getClass())) as
+      | string[]
+      | undefined;
 
+    if (!allowedTokenTypes || allowedTokenTypes.length === 0) {
+      this.logger.debug(`No allowed token type specified, continue`);
+      return true;
+    }
     this.logger.debug(
       `Allowed token types are: [${allowedTokenTypes.join(", ")}]`,
     );

--- a/src/decorators/authenticated/token-types.decorator.ts
+++ b/src/decorators/authenticated/token-types.decorator.ts
@@ -1,5 +1,5 @@
 import { SetMetadata } from "@nestjs/common";
-import { TOKEN_TYPES_METADATA_KEY } from "../constants";
+import { TOKEN_TYPES_METADATA_KEY } from "../../constants";
 
 export const TokenTypes = (...tokenTypes: string[]) =>
   SetMetadata(TOKEN_TYPES_METADATA_KEY, tokenTypes);

--- a/src/decorators/has-permission/has-permission.decorator.ts
+++ b/src/decorators/has-permission/has-permission.decorator.ts
@@ -1,6 +1,6 @@
-import { applyDecorators, UseGuards } from '@nestjs/common';
-import { PermissionsGuard } from './permissions.guard';
-import { PermissionsTypes } from './permissions.types';
+import { applyDecorators, UseGuards } from "@nestjs/common";
+import { PermissionsGuard } from "./permissions.guard";
+import { PermissionsTypes } from "./permissions.types";
 import { AuthGuard } from "../auth.guard";
 
 /**
@@ -11,6 +11,6 @@ import { AuthGuard } from "../auth.guard";
 export function HasPermission(permission: string) {
   return applyDecorators(
     UseGuards(AuthGuard, PermissionsGuard),
-    PermissionsTypes(permission)
+    PermissionsTypes(permission),
   );
 }

--- a/src/decorators/has-permission/has-permission.decorator.ts
+++ b/src/decorators/has-permission/has-permission.decorator.ts
@@ -1,0 +1,16 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { PermissionsGuard } from './permissions.guard';
+import { PermissionsTypes } from './permissions.types';
+import { AuthGuard } from "../auth.guard";
+
+/**
+ * Allows only requests from users with a token in the given types.
+ *
+ * @param permission list of allowed token types
+ */
+export function HasPermission(permission: string) {
+  return applyDecorators(
+    UseGuards(AuthGuard, PermissionsGuard),
+    PermissionsTypes(permission)
+  );
+}

--- a/src/decorators/has-permission/permissions.guard.ts
+++ b/src/decorators/has-permission/permissions.guard.ts
@@ -31,10 +31,6 @@ export class PermissionsGuard implements CanActivate {
         PERMISSIONS_METADATA_KEY,
         context.getClass(),
       )) as string;
-    if (permission === "*") {
-      this.logger.debug("No specific permission required");
-      return true;
-    }
 
     return user.permissions.includes(permission);
   }

--- a/src/decorators/has-permission/permissions.guard.ts
+++ b/src/decorators/has-permission/permissions.guard.ts
@@ -4,8 +4,8 @@ import {
   Injectable,
   Logger,
   Dependencies,
-} from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
 import { getRequest } from "../../utils";
 import { PERMISSIONS_METADATA_KEY } from "../../constants";
 
@@ -25,10 +25,14 @@ export class PermissionsGuard implements CanActivate {
 
     const permission = (this.reflector.get(
       PERMISSIONS_METADATA_KEY,
-      context.getHandler()
-    ) || this.reflector.get(PERMISSIONS_METADATA_KEY, context.getClass())) as string;
+      context.getHandler(),
+    ) ||
+      this.reflector.get(
+        PERMISSIONS_METADATA_KEY,
+        context.getClass(),
+      )) as string;
     if (permission === "*") {
-      this.logger.debug('No specific permission required');
+      this.logger.debug("No specific permission required");
       return true;
     }
 

--- a/src/decorators/has-permission/permissions.guard.ts
+++ b/src/decorators/has-permission/permissions.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  Dependencies,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { getRequest } from "../../utils";
+import { PERMISSIONS_METADATA_KEY } from "../../constants";
+
+@Dependencies(Reflector)
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionsGuard.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  async canActivate(context: ExecutionContext) {
+    const user = getRequest(context).user;
+
+    if (!user?.permissions) {
+      return false;
+    }
+
+    const permission = (this.reflector.get(
+      PERMISSIONS_METADATA_KEY,
+      context.getHandler()
+    ) || this.reflector.get(PERMISSIONS_METADATA_KEY, context.getClass())) as string;
+    if (permission === "*") {
+      this.logger.debug('No specific permission required');
+      return true;
+    }
+
+    return user.permissions.includes(permission);
+  }
+}

--- a/src/decorators/has-permission/permissions.types.ts
+++ b/src/decorators/has-permission/permissions.types.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { PERMISSIONS_METADATA_KEY } from "../../constants";
+
+export const PermissionsTypes = (permission: string) =>
+  SetMetadata(PERMISSIONS_METADATA_KEY, permission);

--- a/src/decorators/has-permission/permissions.types.ts
+++ b/src/decorators/has-permission/permissions.types.ts
@@ -1,4 +1,4 @@
-import { SetMetadata } from '@nestjs/common';
+import { SetMetadata } from "@nestjs/common";
 import { PERMISSIONS_METADATA_KEY } from "../../constants";
 
 export const PermissionsTypes = (permission: string) =>

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,5 +1,5 @@
 export { AccessToken } from "./access-token.decorator";
 export { Authenticated } from "./authenticated/authenticated.decorator";
-export { HasPermission } from './has-permission/has-permission.decorator'
+export { HasPermission } from "./has-permission/has-permission.decorator";
 export { RefreshCookieInterceptor } from "./refresh-cookie.interceptor";
 export { RefreshToken } from "./refresh-token.decorator";

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,4 +1,5 @@
 export { AccessToken } from "./access-token.decorator";
-export { Authenticated } from "./authenticated.decorator";
+export { Authenticated } from "./authenticated/authenticated.decorator";
+export { HasPermission } from './has-permission/has-permission.decorator'
 export { RefreshCookieInterceptor } from "./refresh-cookie.interceptor";
 export { RefreshToken } from "./refresh-token.decorator";

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,6 @@
 export interface User {
   tokenType?: string;
+  permissions?: string[];
 }
 
 export interface Request<U extends User = User> {

--- a/tests/express-graphql.test.ts
+++ b/tests/express-graphql.test.ts
@@ -1,6 +1,11 @@
 import { Test } from "@nestjs/testing";
 import request from "supertest";
-import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
+import {
+  Authenticated,
+  CookieService,
+  HasPermission,
+  SecurityModule,
+} from "../src";
 import { sign } from "jsonwebtoken";
 import {
   Resolver,
@@ -40,7 +45,7 @@ class TestResolver {
       {
         tokenType: "dog",
         uid: "corgi",
-        permissions: ['nickname.read']
+        permissions: ["nickname.read"],
       },
       "secret",
     );

--- a/tests/express-graphql.test.ts
+++ b/tests/express-graphql.test.ts
@@ -1,6 +1,6 @@
 import { Test } from "@nestjs/testing";
 import request from "supertest";
-import { Authenticated, CookieService, SecurityModule } from "../src";
+import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
 import { sign } from "jsonwebtoken";
 import {
   Resolver,
@@ -25,6 +25,9 @@ class Cat {
 
   @Field(() => String)
   name: string;
+
+  @Field(() => String)
+  nickname: string;
 }
 
 @Resolver(() => Cat)
@@ -37,6 +40,7 @@ class TestResolver {
       {
         tokenType: "dog",
         uid: "corgi",
+        permissions: ['nickname.read']
       },
       "secret",
     );
@@ -62,6 +66,12 @@ class TestResolver {
   @Authenticated("dog")
   async name() {
     return "dog";
+  }
+
+  @ResolveField()
+  @HasPermission("nickname.read")
+  async nickname() {
+    return "fuffi";
   }
 }
 
@@ -114,7 +124,7 @@ it(`performs login, query, and logout`, async () => {
     .post("/graphql")
     .set("Cookie", cookies)
     .send({
-      query: `{ cats { hello name } }`,
+      query: `{ cats { hello name nickname } }`,
     });
   expect(queryResult.statusCode).toEqual(200);
 

--- a/tests/express-rest.test.ts
+++ b/tests/express-rest.test.ts
@@ -1,6 +1,11 @@
 import { Test } from "@nestjs/testing";
 import request from "supertest";
-import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
+import {
+  Authenticated,
+  CookieService,
+  HasPermission,
+  SecurityModule,
+} from "../src";
 import { Controller, Get, Post, Req, Res } from "@nestjs/common";
 import { sign } from "jsonwebtoken";
 import { parseExpressCookies } from "./utils";
@@ -18,9 +23,7 @@ class TestController {
       {
         tokenType: "dog",
         uid: "corgi",
-        permissions: [
-          "mouse.read"
-        ]
+        permissions: ["mouse.read"],
       },
       "secret",
     );
@@ -35,6 +38,7 @@ class TestController {
       hello: "world",
     };
   }
+
   @Get("/mouse")
   @HasPermission("mouse.read")
   async mouse() {
@@ -42,7 +46,6 @@ class TestController {
       hello: "squit",
     };
   }
-
 
   @Post("/logout")
   async logout(

--- a/tests/express-rest.test.ts
+++ b/tests/express-rest.test.ts
@@ -1,6 +1,6 @@
 import { Test } from "@nestjs/testing";
 import request from "supertest";
-import { Authenticated, CookieService, SecurityModule } from "../src";
+import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
 import { Controller, Get, Post, Req, Res } from "@nestjs/common";
 import { sign } from "jsonwebtoken";
 import { parseExpressCookies } from "./utils";
@@ -18,6 +18,9 @@ class TestController {
       {
         tokenType: "dog",
         uid: "corgi",
+        permissions: [
+          "mouse.read"
+        ]
       },
       "secret",
     );
@@ -32,6 +35,14 @@ class TestController {
       hello: "world",
     };
   }
+  @Get("/mouse")
+  @HasPermission("mouse.read")
+  async mouse() {
+    return {
+      hello: "squit",
+    };
+  }
+
 
   @Post("/logout")
   async logout(
@@ -76,6 +87,11 @@ it(`performs login, query, and logout`, async () => {
     .get("/cats")
     .set("Cookie", loginResult.get("Set-Cookie"));
   expect(queryResult.statusCode).toEqual(200);
+
+  const permissionQueryResult = await request(app.getHttpServer())
+    .get("/mouse")
+    .set("Cookie", loginResult.get("Set-Cookie"));
+  expect(permissionQueryResult.statusCode).toEqual(200);
 
   const logoutResult = await request(app.getHttpServer())
     .post("/logout")

--- a/tests/fastify-graphql.test.ts
+++ b/tests/fastify-graphql.test.ts
@@ -3,7 +3,12 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from "@nestjs/platform-fastify";
-import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
+import {
+  Authenticated,
+  CookieService,
+  HasPermission,
+  SecurityModule,
+} from "../src";
 import { FastifyRequest, FastifyReply } from "fastify";
 import { sign } from "jsonwebtoken";
 import fastifyCookie from "@fastify/cookie";
@@ -42,9 +47,7 @@ class TestResolver {
       {
         tokenType: "dog",
         uid: "corgi",
-        permissions: [
-          "nickname.read"
-        ]
+        permissions: ["nickname.read"],
       },
       "secret",
     );

--- a/tests/fastify-rest.test.ts
+++ b/tests/fastify-rest.test.ts
@@ -3,7 +3,12 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from "@nestjs/platform-fastify";
-import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
+import {
+  Authenticated,
+  CookieService,
+  HasPermission,
+  SecurityModule,
+} from "../src";
 import { Controller, Get, Post, Req, Res } from "@nestjs/common";
 import { FastifyReply, FastifyRequest } from "fastify";
 import { sign } from "jsonwebtoken";
@@ -20,7 +25,7 @@ class TestController {
       {
         tokenType: "dog",
         uid: "corgi",
-        permissions: ['dogs.read']
+        permissions: ["dogs.read"],
       },
       "secret",
     );
@@ -37,7 +42,7 @@ class TestController {
   }
 
   @Get("/dogs")
-  @HasPermission('dogs.read')
+  @HasPermission("dogs.read")
   async dogs() {
     return {
       hello: "world",

--- a/tests/fastify-rest.test.ts
+++ b/tests/fastify-rest.test.ts
@@ -3,7 +3,7 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from "@nestjs/platform-fastify";
-import { Authenticated, CookieService, SecurityModule } from "../src";
+import { Authenticated, CookieService, HasPermission, SecurityModule } from "../src";
 import { Controller, Get, Post, Req, Res } from "@nestjs/common";
 import { FastifyReply, FastifyRequest } from "fastify";
 import { sign } from "jsonwebtoken";
@@ -20,6 +20,7 @@ class TestController {
       {
         tokenType: "dog",
         uid: "corgi",
+        permissions: ['dogs.read']
       },
       "secret",
     );
@@ -30,6 +31,14 @@ class TestController {
   @Get("/cats")
   @Authenticated("dog")
   async cats() {
+    return {
+      hello: "world",
+    };
+  }
+
+  @Get("/dogs")
+  @HasPermission('dogs.read')
+  async dogs() {
     return {
       hello: "world",
     };
@@ -87,6 +96,13 @@ it(`performs login, query, and logout`, async () => {
     cookies,
   });
   expect(queryResult.statusCode).toEqual(200);
+
+  const queryResultDogs = await app.inject({
+    method: "GET",
+    url: "/dogs",
+    cookies,
+  });
+  expect(queryResultDogs.statusCode).toEqual(200);
 
   const logoutResult = await app.inject({
     method: "POST",


### PR DESCRIPTION
This PR add the `@HasPermission` decorator to the library.

With this new decorator an user can specify also a `permission` array in the token, and check if this array contains the required permission for the declared method or field.

